### PR TITLE
Enable customizable kubelet root

### DIFF
--- a/csi.ini
+++ b/csi.ini
@@ -5,6 +5,7 @@ csi_username=
 csi_password=
 force=No
 verify=Yes
+kubelet_root=/var/lib/kubelet
 plugin_path=docker.io/dellemcstorage/csi-xtremio:v1.1.0-7
 csi_attacher_path=quay.io/k8scsi/csi-attacher:v1.0-canary
 csi_cluster_driver_registrar_path=quay.io/k8scsi/csi-cluster-driver-registrar:v1.0-canary

--- a/csi.ini
+++ b/csi.ini
@@ -6,6 +6,7 @@ csi_password=
 force=No
 verify=Yes
 kubelet_root=/var/lib/kubelet
+iscsi_dir=/var/lib/iscsi
 plugin_path=docker.io/dellemcstorage/csi-xtremio:v1.1.0-7
 csi_attacher_path=quay.io/k8scsi/csi-attacher:v1.0-canary
 csi_cluster_driver_registrar_path=quay.io/k8scsi/csi-cluster-driver-registrar:v1.0-canary

--- a/install-csi-plugin.sh
+++ b/install-csi-plugin.sh
@@ -151,6 +151,7 @@ function create_plugin_yaml() {
     echo "### create plugin yaml file"
 
     sed -i "s/#MANAGEMENT_IP#/$management_ip/g" $PLUGIN_YAML
+    sed -i "s/#KUBELET_ROOT#/${kubelet_root//\//\\/}/g" $PLUGIN_YAML
     sed -i "s/#CSI_USER#/$csi_username/g" $PLUGIN_YAML
     sed -i "s/#STORAGE_CLASS#/$storage_class_name/g" $PLUGIN_YAML
     sed -i "s/#CSI_PROVISIONER#/${csi_provisioner_path//\//\\/}/g" $PLUGIN_YAML

--- a/install-csi-plugin.sh
+++ b/install-csi-plugin.sh
@@ -152,6 +152,7 @@ function create_plugin_yaml() {
 
     sed -i "s/#MANAGEMENT_IP#/$management_ip/g" $PLUGIN_YAML
     sed -i "s/#KUBELET_ROOT#/${kubelet_root//\//\\/}/g" $PLUGIN_YAML
+    sed -i "s/#ISCSI_DIR#/${iscsi_dir//\//\\/}/g" $PLUGIN_YAML
     sed -i "s/#CSI_USER#/$csi_username/g" $PLUGIN_YAML
     sed -i "s/#STORAGE_CLASS#/$storage_class_name/g" $PLUGIN_YAML
     sed -i "s/#CSI_PROVISIONER#/${csi_provisioner_path//\//\\/}/g" $PLUGIN_YAML

--- a/template/plugin-template.yaml
+++ b/template/plugin-template.yaml
@@ -224,7 +224,7 @@ spec:
         # For iscsi
         - name: host-var-iscsi
           hostPath:
-            path: /var/lib/iscsi
+            path: #ISCSI_DIR#
         # For xio_ig_id
         - name: xio-path-ig
           hostPath:

--- a/template/plugin-template.yaml
+++ b/template/plugin-template.yaml
@@ -150,7 +150,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi_node.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/csi-xtremio.dellemc.com/csi_node.sock
+              value: #KUBELET_ROOT#/plugins/csi-xtremio.dellemc.com/csi_node.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -201,15 +201,15 @@ spec:
       volumes:
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: #KUBELET_ROOT#/plugins_registry/
             type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/csi-xtremio.dellemc.com
+            path: #KUBELET_ROOT#/plugins/csi-xtremio.dellemc.com
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: #KUBELET_ROOT#
             type: Directory
         - name: host-dev
           hostPath:


### PR DESCRIPTION
For use with Ubuntu-based or other K8s distros 
e.g. PKS and CFCR uses `/var/vcap/data/kubelet` instead of `/var/lib/kubelet`  and `/etc/iscsi` instead of `/var/lib/iscsi`